### PR TITLE
fixbug: setup.py lack a comma

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         'rouge-score',
         'sacrebleu',
         'sentencepiece',
-        'tensorflow==1.15'
+        'tensorflow==1.15',
         'tensorflow-text==1.15.0rc0',
         'tfds-nightly',
         'tensor2tensor==1.15.0',


### PR DESCRIPTION
`python setup.py install` error: Could not find suitable distribution for Requirement.parse('tensorflow==1.15tensorflow-text==1.15.0rc0')